### PR TITLE
fix: re-render new user data after updating user

### DIFF
--- a/apps/web/src/contexts/auth/context.ts
+++ b/apps/web/src/contexts/auth/context.ts
@@ -1,6 +1,6 @@
 import React, { createContext } from "react";
 
-import { isDef } from "../../utils";
+import { assert, isDef } from "../../utils";
 import { AuthAction, AuthState } from "./reducer";
 
 type AuthStateContextType = {
@@ -21,7 +21,7 @@ export function useAuthState() {
     const context = React.useContext(AuthStateContext);
 
     if (!isDef(context)) {
-        throw new Error("useAuthState must be used within a Context");
+        throw new Error("useAuthState must be used within an AuthStateContext");
     }
 
     return {
@@ -30,11 +30,34 @@ export function useAuthState() {
     };
 }
 
+export function useRegisteredUser() {
+    const context = React.useContext(AuthStateContext);
+
+    if (!isDef(context)) {
+        throw new Error(
+            "useRegisteredUser must be used within an AuthStateContext",
+        );
+    }
+
+    assert(
+        context.state.kind === "logged-in",
+        "useRegisteredUser can only be used when the user is logged in",
+    );
+    assert(
+        context.state.user.kind === "registered",
+        "useRegisteredUser can only be used with a registered user",
+    );
+
+    return context.state.user;
+}
+
 export function useAuthDispatch() {
     const context = React.useContext(AuthStateContext);
 
     if (!isDef(context)) {
-        throw new Error("useAuthDispatch must be used within a Context");
+        throw new Error(
+            "useAuthDispatch must be used within an AuthStateContext",
+        );
     }
 
     return context.update;
@@ -44,7 +67,9 @@ export function useAuth() {
     const context = React.useContext(AuthStateContext);
 
     if (!isDef(context)) {
-        throw new Error("useAuthDispatch must be used within a Context");
+        throw new Error(
+            "useAuthDispatch must be used within an AuthStateContext",
+        );
     }
 
     return [context.state, context.update] as const;

--- a/apps/web/src/forms/UpdateUserForm.tsx
+++ b/apps/web/src/forms/UpdateUserForm.tsx
@@ -1,8 +1,6 @@
 import { css } from "@emotion/css";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Grid from "@mui/material/Grid";
-import { useQueryClient } from "@tanstack/react-query";
-import { useRouter } from "@tanstack/react-router";
 import { TRPCClientError } from "@trpc/client";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
@@ -24,8 +22,6 @@ type UpdateUserFormProps = {
 };
 
 const UpdateUserForm = ({ user, onResponse }: UpdateUserFormProps) => {
-    const router = useRouter();
-    const queryClient = useQueryClient();
     const dispatchAuth = useAuthDispatch();
     const updateWith = trpc.users.update.useMutation();
     const form = useForm<UserUpdate>({

--- a/apps/web/src/forms/UpdateUserForm.tsx
+++ b/apps/web/src/forms/UpdateUserForm.tsx
@@ -50,10 +50,6 @@ const UpdateUserForm = ({ user, onResponse }: UpdateUserFormProps) => {
 
             delete update.password;
             dispatchAuth({ type: "update", payload: { ...user, ...update } });
-
-            // @@Todo: fix re-render of tbe user page.
-            queryClient.invalidateQueries();
-            router.invalidate();
         } catch (e: unknown) {
             if (e instanceof TRPCClientError) {
                 console.log(e);

--- a/apps/web/src/routes/user/settings.tsx
+++ b/apps/web/src/routes/user/settings.tsx
@@ -13,6 +13,7 @@ import Alert, { AlertKind } from "../../components/Alert";
 import Divider from "../../components/Divider";
 import PlayerAvatar from "../../components/PlayerAvatar";
 import { useAuthDispatch } from "../../contexts/auth";
+import { useRegisteredUser } from "../../contexts/auth/context";
 import DeleteUserForm from "../../forms/DeleteUserForm";
 import UpdateUserForm from "../../forms/UpdateUserForm";
 import UpdateUserProfileImageForm from "../../forms/UpdateUserProfileImageForm";
@@ -83,10 +84,6 @@ export const Route = createFileRoute("/user/settings")({
                 },
             });
         }
-
-        return {
-            user: context.auth.user,
-        };
     },
     component: UserSettingsRoute,
 });
@@ -98,7 +95,7 @@ type SettingsEvent = {
 
 function UserSettingsRoute() {
     const [event, setEvent] = useState<SettingsEvent | null>(null);
-    const { user } = Route.useRouteContext();
+    const user = useRegisteredUser();
     const auth = useAuthDispatch();
     const navigator = useNavigate();
 


### PR DESCRIPTION
The `user/settings` route was previously not updating the user data after a user update because the user object was being stored in the route context.

When a user update was dispatched, the `AuthStateContext` would update, but the route would still be using a stale version of the context.

To fix:
- We can retrieve the context state directly at the component level instead of the route level
- This should trigger the component to re-render once the context state changes.
- Added a `useRegisteredUser` hook to return a registered user from the `AuthStateContext`. This hook will throw if used in an invalid context.