### PR TITLE
fix: stale router context

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,7 +2,7 @@ import { ThemeProvider } from "@emotion/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Navigate, RouterProvider, createRouter } from "@tanstack/react-router";
 import { Buffer } from "buffer";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import superjson from "superjson";
 
 import { useAuthState } from "./contexts/auth";
@@ -44,6 +44,10 @@ const App = () => {
     const { state } = useAuthState();
     const [queryClient] = useState(() => new QueryClient());
     const [trpcClient] = useState(createReactQueryTRPClient);
+
+    useEffect(() => {
+        router.invalidate();
+    }, [state]);
 
     return (
         <trpc.Provider client={trpcClient} queryClient={queryClient}>

--- a/apps/web/src/forms/UpdateUserForm.tsx
+++ b/apps/web/src/forms/UpdateUserForm.tsx
@@ -1,8 +1,6 @@
 import { css } from "@emotion/css";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Grid from "@mui/material/Grid";
-import { useQueryClient } from "@tanstack/react-query";
-import { useRouter } from "@tanstack/react-router";
 import { TRPCClientError } from "@trpc/client";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
@@ -24,8 +22,6 @@ type UpdateUserFormProps = {
 };
 
 const UpdateUserForm = ({ user, onResponse }: UpdateUserFormProps) => {
-    const router = useRouter();
-    const queryClient = useQueryClient();
     const dispatchAuth = useAuthDispatch();
     const updateWith = trpc.users.update.useMutation();
     const form = useForm<UserUpdate>({
@@ -50,10 +46,6 @@ const UpdateUserForm = ({ user, onResponse }: UpdateUserFormProps) => {
 
             delete update.password;
             dispatchAuth({ type: "update", payload: { ...user, ...update } });
-
-            // @@Todo: fix re-render of tbe user page.
-            queryClient.invalidateQueries();
-            router.invalidate();
         } catch (e: unknown) {
             if (e instanceof TRPCClientError) {
                 console.log(e);


### PR DESCRIPTION
As the router context is derived from the `AuthStateContext`, we need to invalidate the router whenever the `AuthStateContext` changes to prevent the router context becoming stale, and to reload all the route matches.
