### PR TITLE
chore: update eslintrc to ignore `_` as an unused var

### DIFF
--- a/apps/web/.eslintrc.cjs
+++ b/apps/web/.eslintrc.cjs
@@ -14,5 +14,13 @@ module.exports = {
       'warn',
       { allowConstantExport: true },
     ],
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_",
+          "caughtErrorsIgnorePattern": "^_"
+      }
+    ],
   },
 }

--- a/apps/web/src/components/ControlledPasswordField.tsx
+++ b/apps/web/src/components/ControlledPasswordField.tsx
@@ -18,8 +18,7 @@ export default function ControlledPasswordField<T extends FieldValues>({
 }: Props<T>): ReactElement {
     const [showPassword, setShowPassword] = useState<boolean>(false);
     const {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        field: { ref, ...inputProps },
+        field: { ref: _, ...inputProps },
         fieldState: { error },
     } = useController({
         name,

--- a/apps/web/src/components/ControlledTextField.tsx
+++ b/apps/web/src/components/ControlledTextField.tsx
@@ -14,7 +14,6 @@ const ControlledTextField = <T extends FieldValues>({
     textFieldProps,
 }: ControlledTextFieldProps<T>): ReactElement => {
     const {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         field: { ref: _, ...inputProps },
         fieldState: { error },
     } = useController({


### PR DESCRIPTION
Copying over this rule from the server's ESLint config